### PR TITLE
QOL - Universal Marker Size

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -801,10 +801,10 @@ Citizen.CreateThread(function()
     for k,v in pairs(Config.Zones) do
       if(v.Type ~= -1 and GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < Config.DrawDistance) then
                 if PlayerData.job ~= nil and PlayerData.job.name == 'ambulance' then
-                    DrawMarker(v.Type, v.Pos.x, v.Pos.y, v.Pos.z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, v.Size.x, v.Size.y, v.Size.z, Config.MarkerColor.r, Config.MarkerColor.g, Config.MarkerColor.b, 100, false, true, 2, false, false, false, false)
+                    DrawMarker(v.Type, v.Pos.x, v.Pos.y, v.Pos.z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, Config.MarkerSize.x, Config.MarkerSize.y, Config.MarkerSize.z, Config.MarkerColor.r, Config.MarkerColor.g, Config.MarkerColor.b, 100, false, true, 2, false, false, false, false)
                 elseif k ~= 'AmbulanceActions' and k ~= 'VehicleSpawner' and k ~= 'VehicleDeleter'
                     and k ~= 'Pharmacy' and k ~= 'StairsGoTopBottom' and k ~= 'StairsGoBottomTop' then
-                    DrawMarker(v.Type, v.Pos.x, v.Pos.y, v.Pos.z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, v.Size.x, v.Size.y, v.Size.z, Config.MarkerColor.r, Config.MarkerColor.g, Config.MarkerColor.b, 100, false, true, 2, false, false, false, false)
+                    DrawMarker(v.Type, v.Pos.x, v.Pos.y, v.Pos.z, 0.0, 0.0, 0.0, 0, 0.0, 0.0, Config.MarkerSize.x, Config.MarkerSize.y, Config.MarkerSize.z, Config.MarkerColor.r, Config.MarkerColor.g, Config.MarkerColor.b, 100, false, true, 2, false, false, false, false)
                 end
       end
     end
@@ -820,13 +820,13 @@ Citizen.CreateThread(function()
     local currentZone = nil
     for k,v in pairs(Config.Zones) do
             if PlayerData.job ~= nil and PlayerData.job.name == 'ambulance' then
-                if(GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < v.Size.x) then
+                if(GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < Config.MarkerSize.x) then
                     isInMarker  = true
                     currentZone = k
                 end
             elseif k ~= 'AmbulanceActions' and k ~= 'VehicleSpawner' and k ~= 'VehicleDeleter'
                 and k ~= 'Pharmacy' and k ~= 'StairsGoTopBottom' and k ~= 'StairsGoBottomTop' then
-                if(GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < v.Size.x) then
+                if(GetDistanceBetweenCoords(coords, v.Pos.x, v.Pos.y, v.Pos.z, true) < Config.MarkerSize.x) then
                     isInMarker  = true
                     currentZone = k
                 end

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,7 @@
 Config                            = {}
 Config.DrawDistance               = 100.0
 Config.MarkerColor                = { r = 102, g = 0, b = 102 }
+Config.MarkerSize                 = { x = 1.5, y = 1.5, z = 1.0 }
 
 local second = 1000
 local minute = 60 * second
@@ -49,127 +50,105 @@ Config.Zones = {
 
   HospitalInteriorEntering1 = { -- ok
     Pos  = { x = 294.6, y = -1448.01, z = 28.9 },
-    Size = { x = 1.5, y = 1.5, z = 0.4 },
     Type = 1
   },
 
   HospitalInteriorInside1 = { -- ok
     Pos  = { x = 272.8, y = -1358.8, z = 23.5 },
-    Size = { x = 1.5, y = 1.5, z = 1.0 },
     Type = -1
   },
 
   HospitalInteriorOutside1 = { -- ok
     Pos  = { x = 295.8, y = -1446.5, z = 28.9 },
-    Size = { x = 1.5, y = 1.5, z = 1.0 },
     Type = -1
   },
 
   HospitalInteriorExit1 = { -- ok
     Pos  = { x = 275.7, y = -1361.5, z = 23.5 },
-    Size = { x = 1.5, y = 1.5, z = 0.4 },
     Type = 1
   },
 
   HospitalInteriorEntering2 = { -- Ascenseur aller au toit
     Pos  = { x = 247.1, y = -1371.4, z = 23.5 },
-    Size = { x = 1.5, y = 1.5, z = 0.4 },
     Type = 1
   },
 
   HospitalInteriorInside2 = { -- Toit sortie
     Pos  = { x = 333.1,  y = -1434.9, z = 45.5 },
-    Size = { x = 1.5, y = 1.5, z = 1.0 },
     Type = -1
   },
 
   HospitalInteriorOutside2 = { -- Ascenseur retour depuis toit
     Pos  = { x = 249.1,  y = -1369.6, z = 23.5 },
-    Size = { x = 1.5, y = 1.5, z = 1.0 },
     Type = -1
   },
 
   HospitalInteriorExit2 = { -- Toit entrée
     Pos  = { x = 335.5, y = -1432.0, z = 45.5 },
-    Size = { x = 1.5, y = 1.5, z = 0.4 },
     Type = 1
   },
 
   AmbulanceActions = { -- CLOACKROOM
     Pos  = { x = 268.4, y = -1363.330, z = 23.5 },
-    Size = { x = 1.5, y = 1.5, z = 0.4 },
     Type = 1
   },
 
   VehicleSpawner = {
     Pos  = { x = 307.76, y = -1433.47, z = 28.97 },
-    Size = { x = 1.5, y = 1.5, z = 0.4 },
     Type = 1
   },
 
   VehicleSpawnPoint = {
     Pos  = { x = 304.87, y = -1437.69, z = 28.80 },
-    Size = { x = 1.5, y = 1.5, z = 1.0 },
     Type = -1
   },
 
   VehicleDeleter = {
     Pos  = { x = 327.67, y = -1481.1, z = 28.83 },
-    Size = { x = 3.0, y = 3.0, z = 0.4 },
     Type = 1
   },
 
   Pharmacy = {
     Pos  = { x = 230.13, y = -1366.18, z = 38.53 },
-    Size = { x = 1.5, y = 1.5, z = 0.4 },
     Type = 1
   },
 
   ParkingDoorGoOutInside = {
     Pos  = { x = 234.56, y = -1373.77, z = 20.97 },
-    Size = { x = 1.5, y = 1.5, z = 0.4 },
     Type = 1
   },
 
   ParkingDoorGoOutOutside = {
     Pos  = { x = 320.98, y = -1478.62, z = 28.81 },
-    Size = { x = 1.5, y = 1.5, z = 1.5 },
     Type = -1
   },
 
   ParkingDoorGoInInside = {
     Pos  = { x = 238.64, y = -1368.48, z = 23.53 },
-    Size = { x = 1.5, y = 1.5, z = 1.5 },
     Type = -1
   },
 
   ParkingDoorGoInOutside = {
     Pos  = { x = 317.97, y = -1476.13, z = 28.97 },
-    Size = { x = 1.5, y = 1.5, z = 0.4 },
     Type = 1
   },
 
   StairsGoTopTop = {
     Pos  = { x = 251.91, y = -1363.3, z = 38.53 },
-    Size = { x = 1.5, y = 1.5, z = 1.5 },
     Type = -1
   },
 
   StairsGoTopBottom = {
     Pos  = { x = 237.45, y = -1373.89, z = 26.30 },
-    Size = { x = 3.5, y = 3.5, z = 0.4 },
     Type = -1
   },
 
   StairsGoBottomTop = {
     Pos  = { x = 256.58, y = -1357.7, z = 37.30 },
-    Size = { x = 3.5, y = 3.5, z = 0.4 },
     Type = -1
   },
 
   StairsGoBottomBottom = {
-    Pos  = { x = 240.94, y = -1369.91, z = 23.53 },
-    Size = { x = 1.5, y = 1.5, z = 1.5 },
     Type = -1
   }
 


### PR DESCRIPTION
Synopsis: Adjust Markers to all have one universal size.

Reason for edition: The Marker sizes vary and cause for confusion. It is also very hard to find the vehicle spawner and duty marker at all hospital locations.